### PR TITLE
fix include endian.h

### DIFF
--- a/src/ltc.h
+++ b/src/ltc.h
@@ -48,8 +48,8 @@ extern "C" {
 # if __BYTE_ORDER__ ==  __ORDER_BIG_ENDIAN__
 #  define LTC_BIG_ENDIAN
 # endif
-#else
-# include <machine/endian.h>
+#elif !defined __LITTLE_ENDIAN__
+# include <endian.h>
 # if __BYTE_ORDER__ ==  __ORDER_BIG_ENDIAN__
 #  define LTC_BIG_ENDIAN
 # endif


### PR DESCRIPTION
I have a problem including endian.h. 
May this pull request fix the problem?
