### PR TITLE
Define inline keyword for builds on VS2013

### DIFF
--- a/src/decoder.c
+++ b/src/decoder.c
@@ -101,6 +101,10 @@
 	printf("\n"); \
 }
 
+#if (defined _MSC_VER && _MSC_VER <= 1800)
+#define inline __inline
+#endif
+
 #if (!defined INFINITY && defined _MSC_VER)
 #define INFINITY std::numeric_limits<double>::infinity()
 #endif


### PR DESCRIPTION
There doesn't seem to be information available on this being implemented in VS2015.
https://msdn.microsoft.com/en-us/library/hh409293.aspx - suggests that C99 features are supported.