### PR TITLE
Writing in user bytes

### DIFF
--- a/src/ltc.c
+++ b/src/ltc.c
@@ -268,6 +268,46 @@ void ltc_encoder_set_timecode(LTCEncoder *e, SMPTETimecode *t) {
 	ltc_time_to_frame(&e->f, t, e->standard, e->flags);
 }
 
+void ltc_encoder_set_user_bits(LTCEncoder *e, unsigned long data){
+	LTCFrame *f = &(e->f);
+	f->user1 = data & 0xF;
+	data >>= 4;
+	f->user2 = data & 0xF;
+	data >>= 4;
+	f->user3 = data & 0xF;
+	data >>= 4;
+	f->user4 = data & 0xF;
+	data >>= 4;
+	f->user5 = data & 0xF;
+	data >>= 4;
+	f->user6 = data & 0xF;
+	data >>= 4;
+	f->user7 = data & 0xF;
+	data >>= 4;
+	f->user8 = data & 0xF;
+	data >>= 4;
+}
+
+unsigned long ltc_frame_get_user_bits(LTCFrame *f){
+	unsigned long data = 0;
+	data += f->user8;
+	data <<= 4;
+	data += f->user7;
+	data <<= 4;
+	data += f->user6;
+	data <<= 4;
+	data += f->user5;
+	data <<= 4;
+	data += f->user4;
+	data <<= 4;
+	data += f->user3;
+	data <<= 4;
+	data += f->user2;
+	data <<= 4;
+	data += f->user1;
+	return data;
+}
+
 void ltc_encoder_get_frame(LTCEncoder *e, LTCFrame *f) {
 	memcpy(f, &e->f, sizeof(LTCFrame));
 }

--- a/src/ltc.h
+++ b/src/ltc.h
@@ -540,6 +540,26 @@ void ltc_encoder_set_timecode(LTCEncoder *e, SMPTETimecode *t);
 void ltc_encoder_get_timecode(LTCEncoder *e, SMPTETimecode *t);
 
 /**
+* Set the user-bits of the frame to the given data.
+*
+* The data should be a 32-bits unsigned integer.
+* It is written LSB first continiously int the eight user fields.
+*
+* @param e encoder handle
+* @param data the data to write
+*/
+void ltc_encoder_set_user_bits(LTCEncoder *e, unsigned long data);
+
+/**
+* Get a 32-bits unsigned integer from the user-data bits.
+* The data should be written LSB first in the frame
+*
+* @param e encoder handle
+*/
+
+unsigned long ltc_frame_get_user_bits(LTCFrame *f);
+
+/**
  * Move the encoder to the next timecode frame.
  * uses \ref ltc_frame_increment() internally.
  */


### PR DESCRIPTION
Able to write custom values in user bytes.
These bytes can now be used to write a 32-bits unsigned integer if the user don't want to write a SMPTE timecode. They are written LSB-first to comply with the LTC standard.
