### PR TITLE
renamed ltc_encoder_set_bufsize and ltc_encoder_get_buffer to more descriptive/consistent names

### DIFF
--- a/src/ltc.c
+++ b/src/ltc.c
@@ -251,14 +251,18 @@ void ltc_encoder_set_filter(LTCEncoder *e, double rise_time) {
 }
 
 int ltc_encoder_set_bufsize(LTCEncoder *e, double sample_rate, double fps) {
-	free (e->buf);
-	e->offset = 0;
-	e->bufsize = 1 + ceil(sample_rate / fps);
-	e->buf = (ltcsnd_sample_t*) calloc(e->bufsize, sizeof(ltcsnd_sample_t));
-	if (!e->buf) {
-		return -1;
-	}
-	return 0;
+	return ltc_encoder_set_buffersize(e, sample_rate, fps);
+}
+
+int ltc_encoder_set_buffersize(LTCEncoder *e, double sample_rate, double fps) {
+    free (e->buf);
+    e->offset = 0;
+    e->bufsize = 1 + ceil(sample_rate / fps);
+    e->buf = (ltcsnd_sample_t*) calloc(e->bufsize, sizeof(ltcsnd_sample_t));
+    if (!e->buf) {
+        return -1;
+    }
+    return 0;
 }
 
 int ltc_encoder_encode_byte(LTCEncoder *e, int byte, double speed) {
@@ -357,10 +361,14 @@ ltcsnd_sample_t *ltc_encoder_get_bufptr(LTCEncoder *e, int *size, int flush) {
 }
 
 int ltc_encoder_get_buffer(LTCEncoder *e, ltcsnd_sample_t *buf) {
-	const int len = e->offset;
-	memcpy(buf, e->buf, len * sizeof(ltcsnd_sample_t) );
-	e->offset = 0;
-	return(len);
+    return ltc_encoder_copy_buffer(e, buf);
+}
+
+int ltc_encoder_copy_buffer(LTCEncoder *e, ltcsnd_sample_t *buf) {
+    const int len = e->offset;
+    memcpy(buf, e->buf, len * sizeof(ltcsnd_sample_t) );
+    e->offset = 0;
+    return len;
 }
 
 void ltc_frame_set_parity(LTCFrame *frame, enum LTC_TV_STANDARD standard) {

--- a/src/ltc.h
+++ b/src/ltc.h
@@ -59,6 +59,12 @@ extern "C" {
 # endif
 #endif
 
+#if defined(__GNUC__) && __GNUC__ >= 4
+# define DEPRECATED_EXPORT __attribute__((__deprecated__))
+#else
+# define DEPRECATED_EXPORT
+#endif
+
 #include <stddef.h> /* size_t */
 
 #ifndef DOXYGEN_IGNORE
@@ -610,9 +616,21 @@ void ltc_encoder_get_frame(LTCEncoder *e, LTCFrame *f);
  * to hold \ref ltc_encoder_get_buffersize bytes
  * @return the number of bytes written to the memory area
  * pointed to by buf.
+ * @deprecated please use ltc_encoder_copy_buffer() instead
  */
-int ltc_encoder_get_buffer(LTCEncoder *e, ltcsnd_sample_t *buf);
+int ltc_encoder_get_buffer(LTCEncoder *e, ltcsnd_sample_t *buf) DEPRECATED_EXPORT;
 
+/**
+* Copy the accumulated encoded audio to the given
+* sample-buffer and flush the internal buffer.
+*
+* @param e encoder handle
+* @param buf place to store the audio-samples, needs to be large enough
+* to hold \ref ltc_encoder_get_buffersize bytes
+* @return the number of bytes written to the memory area
+* pointed to by buf.
+*/
+int ltc_encoder_copy_buffer(LTCEncoder *e, ltcsnd_sample_t *buf);
 
 /**
  * Retrieve a pointer to the accumulated encoded audio-data.
@@ -695,8 +713,28 @@ void ltc_encoder_reset(LTCEncoder *e);
  * @param fps video-frames per second (e.g. 25.0)
  * @return 0 on success, -1 if allocation fails (which makes the
  *   encoder unusable, call \ref ltc_encoder_free or realloc the buffer)
+ * @deprecated please use ltc_encoder_set_buffersize() instead
  */
-int ltc_encoder_set_bufsize(LTCEncoder *e, double sample_rate, double fps);
+int ltc_encoder_set_bufsize(LTCEncoder *e, double sample_rate, double fps) DEPRECATED_EXPORT;
+
+/**
+ * Configure a custom size for the internal buffer.
+ *
+ * This is needed if you are planning to call \ref ltc_encoder_reinit()
+ * or if you want to keep more than one LTC frame's worth of data in
+ * the library's internal buffer.
+ *
+ * The buffer-size is (1 + sample_rate / fps) bytes.
+ * resizing the internal buffer will flush all existing data
+ * in it - alike \ref ltc_encoder_buffer_flush.
+ *
+ * @param e encoder handle
+ * @param sample_rate audio sample rate (eg. 48000)
+ * @param fps video-frames per second (e.g. 25.0)
+ * @return 0 on success, -1 if allocation fails (which makes the
+ *   encoder unusable, call \ref ltc_encoder_free or realloc the buffer)
+ */
+int ltc_encoder_set_buffersize(LTCEncoder *e, double sample_rate, double fps);
 
 /**
  * Query the volume of the generated LTC signal


### PR DESCRIPTION
PR for #45