### PR TITLE
added function and improved argument order consistency

### DIFF
--- a/src/ltc.c
+++ b/src/ltc.c
@@ -251,14 +251,18 @@ void ltc_encoder_set_filter(LTCEncoder *e, double rise_time) {
 }
 
 int ltc_encoder_set_bufsize(LTCEncoder *e, double sample_rate, double fps) {
-	free (e->buf);
-	e->offset = 0;
-	e->bufsize = 1 + ceil(sample_rate / fps);
-	e->buf = (ltcsnd_sample_t*) calloc(e->bufsize, sizeof(ltcsnd_sample_t));
-	if (!e->buf) {
-		return -1;
-	}
-	return 0;
+	return ltc_encoder_set_buffersize(e, sample_rate, fps);
+}
+
+int ltc_encoder_set_buffersize(LTCEncoder *e, double sample_rate, double fps) {
+    free (e->buf);
+    e->offset = 0;
+    e->bufsize = 1 + ceil(sample_rate / fps);
+    e->buf = (ltcsnd_sample_t*) calloc(e->bufsize, sizeof(ltcsnd_sample_t));
+    if (!e->buf) {
+        return -1;
+    }
+    return 0;
 }
 
 int ltc_encoder_encode_byte(LTCEncoder *e, int byte, double speed) {
@@ -357,10 +361,14 @@ ltcsnd_sample_t *ltc_encoder_get_bufptr(LTCEncoder *e, int *size, int flush) {
 }
 
 int ltc_encoder_get_buffer(LTCEncoder *e, ltcsnd_sample_t *buf) {
-	const int len = e->offset;
-	memcpy(buf, e->buf, len * sizeof(ltcsnd_sample_t) );
-	e->offset = 0;
-	return(len);
+    return ltc_encoder_copy_buffer(e, buf);
+}
+
+int ltc_encoder_copy_buffer(LTCEncoder *e, ltcsnd_sample_t *buf) {
+    const int len = e->offset;
+    memcpy(buf, e->buf, len * sizeof(ltcsnd_sample_t) );
+    e->offset = 0;
+    return len;
 }
 
 void ltc_frame_set_parity(LTCFrame *frame, enum LTC_TV_STANDARD standard) {

--- a/src/ltc.c
+++ b/src/ltc.c
@@ -350,14 +350,25 @@ size_t ltc_encoder_get_buffersize(LTCEncoder *e) {
 	return(e->bufsize);
 }
 
+size_t ltc_encoder_get_bufferoffset(LTCEncoder *e) {
+        return e->offset;
+}
+
 void ltc_encoder_buffer_flush(LTCEncoder *e) {
 	e->offset = 0;
 }
 
 ltcsnd_sample_t *ltc_encoder_get_bufptr(LTCEncoder *e, int *size, int flush) {
-	if (size) *size = e->offset;
-	if (flush) e->offset = 0;
-	return e->buf;
+        ltcsnd_sample_t *buf;
+        *size = ltc_encoder_get_bufferptr(e, buf, flush);
+        return buf;
+}
+
+int ltc_encoder_get_bufferptr(LTCEncoder *e, ltcsnd_sample_t *buf, int flush) {
+        const int len = e->offset;
+        if (buf) *buf = e->buf;
+        if (flush) e->offset = 0;
+        return len;
 }
 
 int ltc_encoder_get_buffer(LTCEncoder *e, ltcsnd_sample_t *buf) {

--- a/src/ltc.h
+++ b/src/ltc.h
@@ -639,8 +639,19 @@ int ltc_encoder_copy_buffer(LTCEncoder *e, ltcsnd_sample_t *buf);
  * @param size if set, the number of valid bytes in the buffer is stored there
  * @param flush call \ref ltc_encoder_buffer_flush - reset the buffer write-pointer
  * @return pointer to encoder-buffer
+ * @deprecated please use ltc_encoder_get_bufferptr() instead
  */
-ltcsnd_sample_t *ltc_encoder_get_bufptr(LTCEncoder *e, int *size, int flush);
+ltcsnd_sample_t *ltc_encoder_get_bufptr(LTCEncoder *e, int *size, int flush) DEPRECATED_EXPORT;
+
+/**
+ * Retrieve a pointer to the accumulated encoded audio-data.
+ *
+ * @param e encoder handle
+ * @param size if set, the number of valid bytes in the buffer is stored there
+ * @param flush call \ref ltc_encoder_buffer_flush - reset the buffer write-pointer
+ * @return pointer to encoder-buffer
+ */
+int ltc_encoder_get_bufferptr(LTCEncoder *e, ltcsnd_sample_t *buf, int flush);
 
 /**
  * reset the write-pointer of the encoder-buffer
@@ -654,12 +665,25 @@ void ltc_encoder_buffer_flush(LTCEncoder *e);
  * sample-rate and frame-rate.  ie. (1 + sample-rate / fps) bytes
  *
  * Note this returns the total size of the buffer, not the used/free
- * part. See also \ref ltc_encoder_get_bufptr
+ * part. See also \ref ltc_encoder_get_bufferptr
  *
  * @param e encoder handle
  * @return size of the allocated internal buffer.
  */
 size_t ltc_encoder_get_buffersize(LTCEncoder *e);
+
+/**
+ * Query the offset into the internal buffer. It is allocated
+ * to hold audio-frames for exactly one LTC frame for the given
+ * sample-rate and frame-rate.  ie. (1 + sample-rate / fps) bytes
+ *
+ * Note that this returns the used/free part of the buffer,
+ * not the total size. See also \ref ltc_encoder_get_bufferptr
+ *
+ * @param e encoder handle
+ * @return size of the offset into the internal buffer.
+ */
+size_t ltc_encoder_get_bufferoffset(LTCEncoder *e);
 
 /**
  * Change the encoder settings without re-allocating any
@@ -668,7 +692,7 @@ size_t ltc_encoder_get_buffersize(LTCEncoder *e);
  * and biphase state reset.
  *
  * This call will fail if the internal buffer is too small
- * to hold one full LTC frame. Use \ref ltc_encoder_set_bufsize to
+ * to hold one full LTC frame. Use \ref ltc_encoder_set_buffersize to
  * prepare an internal buffer large enough to accommodate all
  * sample_rate, fps combinations that you would like to re-init to.
  *
@@ -792,7 +816,7 @@ void ltc_encoder_set_filter(LTCEncoder *e, double rise_time);
  * Generate LTC audio for given byte of the LTC-frame and
  * place it into the internal buffer.
  *
- * see \ref ltc_encoder_get_buffer and  \ref ltc_encoder_get_bufptr
+ * see \ref ltc_encoder_copy_buffer and  \ref ltc_encoder_get_bufferptr
  *
  * LTC has 10 bytes per frame: 0 <= bytecnt < 10
  * use SMPTESetTime(..) to set the current frame before Encoding.
@@ -802,7 +826,7 @@ void ltc_encoder_set_filter(LTCEncoder *e, double rise_time);
  * see also \ref ltc_encoder_set_volume
  *
  * if speed is < 0, the bits are encoded in reverse.
- * slowdown > 10.0 requires custom buffer sizes; see \ref ltc_encoder_set_bufsize
+ * slowdown > 10.0 requires custom buffer sizes; see \ref ltc_encoder_set_buffersize
  *
  * @param e encoder handle
  * @param byte byte of the LTC-frame to encode 0..9
@@ -819,7 +843,7 @@ int ltc_encoder_encode_byte(LTCEncoder *e, int byte, double speed);
  *
  * Note: The internal buffer must be empty before calling this function.
  * Otherwise it may overflow. This is usually the case if it is read with
- * \ref ltc_encoder_get_buffer after calling this function.
+ * \ref ltc_encoder_copy_buffer after calling this function.
  *
  * The default internal buffersize is exactly one full LTC frame at speed 1.0.
  *
@@ -834,7 +858,7 @@ void ltc_encoder_encode_frame(LTCEncoder *e);
  *
  * Note: The internal buffer must be empty before calling this function.
  * Otherwise it may overflow. This is usually the case if it is read with
- * \ref ltc_encoder_get_buffer after calling this function.
+ * \ref ltc_encoder_copy_buffer after calling this function.
  *
  * @param e encoder handle
  */

--- a/src/ltc.h
+++ b/src/ltc.h
@@ -59,6 +59,12 @@ extern "C" {
 # endif
 #endif
 
+#if defined(__GNUC__) && __GNUC__ >= 4
+# define DEPRECATED_EXPORT __attribute__((__deprecated__))
+#else
+# define DEPRECATED_EXPORT
+#endif
+
 #include <stddef.h> /* size_t */
 
 #ifndef DOXYGEN_IGNORE
@@ -610,9 +616,21 @@ void ltc_encoder_get_frame(LTCEncoder *e, LTCFrame *f);
  * to hold \ref ltc_encoder_get_buffersize bytes
  * @return the number of bytes written to the memory area
  * pointed to by buf.
+ * @deprecated please use ltc_encoder_copy_buffer() instead
  */
-int ltc_encoder_get_buffer(LTCEncoder *e, ltcsnd_sample_t *buf);
+int ltc_encoder_get_buffer(LTCEncoder *e, ltcsnd_sample_t *buf) DEPRECATED_EXPORT;
 
+/**
+* Copy the accumulated encoded audio to the given
+* sample-buffer and flush the internal buffer.
+*
+* @param e encoder handle
+* @param buf place to store the audio-samples, needs to be large enough
+* to hold \ref ltc_encoder_get_buffersize bytes
+* @return the number of bytes written to the memory area
+* pointed to by buf.
+*/
+int ltc_encoder_copy_buffer(LTCEncoder *e, ltcsnd_sample_t *buf);
 
 /**
  * Retrieve a pointer to the accumulated encoded audio-data.
@@ -695,8 +713,28 @@ void ltc_encoder_reset(LTCEncoder *e);
  * @param fps video-frames per second (e.g. 25.0)
  * @return 0 on success, -1 if allocation fails (which makes the
  *   encoder unusable, call \ref ltc_encoder_free or realloc the buffer)
+ * @deprecated please use ltc_encoder_set_buffersize() instead
  */
-int ltc_encoder_set_bufsize(LTCEncoder *e, double sample_rate, double fps);
+int ltc_encoder_set_bufsize(LTCEncoder *e, double sample_rate, double fps) DEPRECATED_EXPORT;
+
+/**
+ * Configure a custom size for the internal buffer.
+ *
+ * This is needed if you are planning to call \ref ltc_encoder_reinit()
+ * or if you want to keep more than one LTC frame's worth of data in
+ * the library's internal buffer.
+ *
+ * The buffer-size is (1 + sample_rate / fps) bytes.
+ * resizing the internal buffer will flush all existing data
+ * in it - alike \ref ltc_encoder_buffer_flush.
+ *
+ * @param e encoder handle
+ * @param sample_rate audio sample rate (eg. 48000)
+ * @param fps video-frames per second (e.g. 25.0)
+ * @return 0 on success, -1 if allocation fails (which makes the
+ *   encoder unusable, call \ref ltc_encoder_free or realloc the buffer)
+ */
+int ltc_encoder_set_buffersize(LTCEncoder *e, double sample_rate, double fps);
 
 /**
  * Query the volume of the generated LTC signal


### PR DESCRIPTION
I send you a PR for the following:

1) I added
`size_t ltc_encoder_get_bufferoffset(LTCEncoder *e)`
 to query the write offset of the internal buffer.
I found this very useful in a variety of situations, especially when the size of the internal buffer is larger than exactly 1 frame of LTC. In my specific user case I need to change FPS in real-time so I have to allocate a buffer large enough to hold the lowest FPS allowed. However I can see how this could come handy also in situations where you want to speed-up or slow-down the timecode.
It is true that you get the offset when you get the buffer anyway, but sometimes I found myself in need of the offset only.

2) I changed and renamed
`ltcsnd_sample_t *ltc_encoder_get_bufptr(LTCEncoder *e, int *size, int flush)`
to
`int ltc_encoder_get_bufferptr(LTCEncoder *e, ltcsnd_sample_t *buf, int flush)`
The argument order of the latter function is now consistent with get_buffer, copy_buffer, etc...
Obviously I deprecated the former and exported it exactly like I did previously for other functions. So nothing should break.

3) Comments updated to refer to the new function names
