### PR TITLE
general changes and improvements

### DIFF
--- a/src/ltc.c
+++ b/src/ltc.c
@@ -251,14 +251,18 @@ void ltc_encoder_set_filter(LTCEncoder *e, double rise_time) {
 }
 
 int ltc_encoder_set_bufsize(LTCEncoder *e, double sample_rate, double fps) {
-	free (e->buf);
-	e->offset = 0;
-	e->bufsize = 1 + ceil(sample_rate / fps);
-	e->buf = (ltcsnd_sample_t*) calloc(e->bufsize, sizeof(ltcsnd_sample_t));
-	if (!e->buf) {
-		return -1;
-	}
-	return 0;
+	return ltc_encoder_set_buffersize(e, sample_rate, fps);
+}
+
+int ltc_encoder_set_buffersize(LTCEncoder *e, double sample_rate, double fps) {
+    free (e->buf);
+    e->offset = 0;
+    e->bufsize = 1 + ceil(sample_rate / fps);
+    e->buf = (ltcsnd_sample_t*) calloc(e->bufsize, sizeof(ltcsnd_sample_t));
+    if (!e->buf) {
+        return -1;
+    }
+    return 0;
 }
 
 int ltc_encoder_encode_byte(LTCEncoder *e, int byte, double speed) {
@@ -357,10 +361,14 @@ ltcsnd_sample_t *ltc_encoder_get_bufptr(LTCEncoder *e, int *size, int flush) {
 }
 
 int ltc_encoder_get_buffer(LTCEncoder *e, ltcsnd_sample_t *buf) {
-	const int len = e->offset;
-	memcpy(buf, e->buf, len * sizeof(ltcsnd_sample_t) );
-	e->offset = 0;
-	return(len);
+    return ltc_encoder_copy_buffer(e, buf);
+}
+
+int ltc_encoder_copy_buffer(LTCEncoder *e, ltcsnd_sample_t *buf) {
+    const int len = e->offset;
+    memcpy(buf, e->buf, len * sizeof(ltcsnd_sample_t) );
+    e->offset = 0;
+    return len;
 }
 
 void ltc_frame_set_parity(LTCFrame *frame, enum LTC_TV_STANDARD standard) {

--- a/src/ltc.c
+++ b/src/ltc.c
@@ -312,21 +312,21 @@ void ltc_encoder_set_user_bits(LTCEncoder *e, unsigned long data){
 
 unsigned long ltc_frame_get_user_bits(LTCFrame *f){
 	unsigned long data = 0;
-	data += f->user8;
+	data |= f->user8;
 	data <<= 4;
-	data += f->user7;
+	data |= f->user7;
 	data <<= 4;
-	data += f->user6;
+	data |= f->user6;
 	data <<= 4;
-	data += f->user5;
+	data |= f->user5;
 	data <<= 4;
-	data += f->user4;
+	data |= f->user4;
 	data <<= 4;
-	data += f->user3;
+	data |= f->user3;
 	data <<= 4;
-	data += f->user2;
+	data |= f->user2;
 	data <<= 4;
-	data += f->user1;
+	data |= f->user1;
 	return data;
 }
 
@@ -348,10 +348,6 @@ int ltc_encoder_dec_timecode(LTCEncoder *e) {
 
 size_t ltc_encoder_get_buffersize(LTCEncoder *e) {
 	return(e->bufsize);
-}
-
-size_t ltc_encoder_get_bufferoffset(LTCEncoder *e) {
-        return e->offset;
 }
 
 void ltc_encoder_buffer_flush(LTCEncoder *e) {

--- a/src/ltc.c
+++ b/src/ltc.c
@@ -358,17 +358,17 @@ void ltc_encoder_buffer_flush(LTCEncoder *e) {
 	e->offset = 0;
 }
 
-ltcsnd_sample_t *ltc_encoder_get_bufptr(LTCEncoder *e, int *size, int flush) {
-        ltcsnd_sample_t *buf;
-        *size = ltc_encoder_get_bufferptr(e, buf, flush);
-        return buf;
-}
-
-int ltc_encoder_get_bufferptr(LTCEncoder *e, ltcsnd_sample_t *buf, int flush) {
+int ltc_encoder_get_bufferptr(LTCEncoder *e, ltcsnd_sample_t **buf, int flush) {
         const int len = e->offset;
         if (buf) *buf = e->buf;
         if (flush) e->offset = 0;
         return len;
+}
+
+ltcsnd_sample_t *ltc_encoder_get_bufptr(LTCEncoder *e, int *size, int flush) {
+        ltcsnd_sample_t *buf;
+        *size = ltc_encoder_get_bufferptr(e, &buf, flush);
+        return buf;
 }
 
 int ltc_encoder_copy_buffer(LTCEncoder *e, ltcsnd_sample_t *buf) {

--- a/src/ltc.c
+++ b/src/ltc.c
@@ -350,14 +350,25 @@ size_t ltc_encoder_get_buffersize(LTCEncoder *e) {
 	return(e->bufsize);
 }
 
+size_t ltc_encoder_get_bufferoffset(LTCEncoder *e) {
+        return e->offset;
+}
+
 void ltc_encoder_buffer_flush(LTCEncoder *e) {
 	e->offset = 0;
 }
 
 ltcsnd_sample_t *ltc_encoder_get_bufptr(LTCEncoder *e, int *size, int flush) {
-	if (size) *size = e->offset;
-	if (flush) e->offset = 0;
-	return e->buf;
+        ltcsnd_sample_t *buf;
+        *size = ltc_encoder_get_bufferptr(e, buf, flush);
+        return buf;
+}
+
+int ltc_encoder_get_bufferptr(LTCEncoder *e, ltcsnd_sample_t *buf, int flush) {
+        const int len = e->offset;
+        if (buf) *buf = e->buf;
+        if (flush) e->offset = 0;
+        return len;
 }
 
 int ltc_encoder_get_buffer(LTCEncoder *e, ltcsnd_sample_t *buf) {

--- a/src/ltc.h
+++ b/src/ltc.h
@@ -673,19 +673,6 @@ void ltc_encoder_buffer_flush(LTCEncoder *e);
 size_t ltc_encoder_get_buffersize(LTCEncoder *e);
 
 /**
- * Query the offset into the internal buffer. It is allocated
- * to hold audio-frames for exactly one LTC frame for the given
- * sample-rate and frame-rate.  ie. (1 + sample-rate / fps) bytes
- *
- * Note that this returns the used/free part of the buffer,
- * not the total size. See also \ref ltc_encoder_get_bufferptr
- *
- * @param e encoder handle
- * @return size of the offset into the internal buffer.
- */
-size_t ltc_encoder_get_bufferoffset(LTCEncoder *e);
-
-/**
  * Change the encoder settings without re-allocating any
  * library internal data structure (realtime safe).
  * changing the fps and or sample-rate implies a buffer flush,
@@ -893,7 +880,7 @@ void ltc_frame_set_parity(LTCFrame *frame, enum LTC_TV_STANDARD standard);
  * @param standard the TV standard to use -- see \ref LTCFrame for BGF assignment
  * @return LTC Binary Group Flags
  */
-int parse_bcg_flags(LTCFrame *f, enum LTC_TV_STANDARD standard);
+int ltc_frame_parse_bcg_flags(LTCFrame *frame, enum LTC_TV_STANDARD standard);
 
 /**
  * LTCFrame sample alignment offset.

--- a/src/ltc.h
+++ b/src/ltc.h
@@ -879,6 +879,19 @@ void ltc_frame_set_parity(LTCFrame *frame, enum LTC_TV_STANDARD standard);
  * @param f LTC frame data analyze
  * @param standard the TV standard to use -- see \ref LTCFrame for BGF assignment
  * @return LTC Binary Group Flags
+ * @deprecated please use ltc_frame_parse_bcg_flags() instead
+ */
+int parse_bcg_flags(LTCFrame *frame, enum LTC_TV_STANDARD standard) DEPRECATED_EXPORT;
+
+/**
+ * Parse Binary Group Flags into standard independent format:
+ * bit 0 (1) - BGF 0,
+ * bit 1 (2) - BGF 1,
+ * bit 2 (4) - BGF 2
+ *
+ * @param f LTC frame data analyze
+ * @param standard the TV standard to use -- see \ref LTCFrame for BGF assignment
+ * @return LTC Binary Group Flags
  */
 int ltc_frame_parse_bcg_flags(LTCFrame *frame, enum LTC_TV_STANDARD standard);
 

--- a/src/ltc.h
+++ b/src/ltc.h
@@ -557,22 +557,22 @@ void ltc_encoder_set_timecode(LTCEncoder *e, SMPTETimecode *t);
 void ltc_encoder_get_timecode(LTCEncoder *e, SMPTETimecode *t);
 
 /**
-* Set the user-bits of the frame to the given data.
-*
-* The data should be a 32-bits unsigned integer.
-* It is written LSB first continiously int the eight user fields.
-*
-* @param e encoder handle
-* @param data the data to write
-*/
+ * Set the user-bits of the frame to the given data.
+ *
+ * The data should be a 32-bits unsigned integer.
+ * It is written LSB first continiously int the eight user fields.
+ *
+ * @param e encoder handle
+ * @param data the data to write
+ */
 void ltc_encoder_set_user_bits(LTCEncoder *e, unsigned long data);
 
 /**
-* Get the 32-bits unsigned integer from the user-data bits.
-* The data should be written LSB first in the frame
-*
-* @param f LTC frame data to parse
-*/
+ * Get the 32-bits unsigned integer from the user-data bits.
+ * The data should be written LSB first in the frame
+ *
+ * @param f LTC frame data to parse
+ */
 unsigned long ltc_frame_get_user_bits(LTCFrame *f);
 
 /**
@@ -621,15 +621,15 @@ void ltc_encoder_get_frame(LTCEncoder *e, LTCFrame *f);
 int ltc_encoder_get_buffer(LTCEncoder *e, ltcsnd_sample_t *buf) DEPRECATED_EXPORT;
 
 /**
-* Copy the accumulated encoded audio to the given
-* sample-buffer and flush the internal buffer.
-*
-* @param e encoder handle
-* @param buf place to store the audio-samples, needs to be large enough
-* to hold \ref ltc_encoder_get_buffersize bytes
-* @return the number of bytes written to the memory area
-* pointed to by buf.
-*/
+ * Copy the accumulated encoded audio to the given
+ * sample-buffer and flush the internal buffer.
+ *
+ * @param e encoder handle
+ * @param buf place to store the audio-samples, needs to be large enough
+ * to hold \ref ltc_encoder_get_buffersize bytes
+ * @return the number of bytes written to the memory area
+ * pointed to by buf.
+ */
 int ltc_encoder_copy_buffer(LTCEncoder *e, ltcsnd_sample_t *buf);
 
 /**
@@ -647,11 +647,11 @@ ltcsnd_sample_t *ltc_encoder_get_bufptr(LTCEncoder *e, int *size, int flush) DEP
  * Retrieve a pointer to the accumulated encoded audio-data.
  *
  * @param e encoder handle
- * @param size if set, the number of valid bytes in the buffer is stored there
+ * @param buf if set, the pointer to encoder-buffer
  * @param flush call \ref ltc_encoder_buffer_flush - reset the buffer write-pointer
- * @return pointer to encoder-buffer
+ * @return the number of valid bytes in the buffer
  */
-int ltc_encoder_get_bufferptr(LTCEncoder *e, ltcsnd_sample_t *buf, int flush);
+int ltc_encoder_get_bufferptr(LTCEncoder *e, ltcsnd_sample_t **buf, int flush);
 
 /**
  * reset the write-pointer of the encoder-buffer
@@ -787,11 +787,11 @@ double ltc_encoder_get_volume(LTCEncoder *e);
 int ltc_encoder_set_volume(LTCEncoder *e, double dBFS);
 
 /**
-* Get encoder signal rise-time / signal filtering
-*
-* @param e encoder handle
-* @return the signal rise-time in us (10^(-6) sec)
-*/
+ * Get encoder signal rise-time / signal filtering
+ *
+ * @param e encoder handle
+ * @return the signal rise-time in us (10^(-6) sec)
+ */
 double ltc_encoder_get_filter(LTCEncoder *e);
 
 /**

--- a/src/ltc.h
+++ b/src/ltc.h
@@ -639,8 +639,19 @@ int ltc_encoder_copy_buffer(LTCEncoder *e, ltcsnd_sample_t *buf);
  * @param size if set, the number of valid bytes in the buffer is stored there
  * @param flush call \ref ltc_encoder_buffer_flush - reset the buffer write-pointer
  * @return pointer to encoder-buffer
+ * @deprecated please use ltc_encoder_get_bufferptr() instead
  */
-ltcsnd_sample_t *ltc_encoder_get_bufptr(LTCEncoder *e, int *size, int flush);
+ltcsnd_sample_t *ltc_encoder_get_bufptr(LTCEncoder *e, int *size, int flush) DEPRECATED_EXPORT;
+
+/**
+ * Retrieve a pointer to the accumulated encoded audio-data.
+ *
+ * @param e encoder handle
+ * @param size if set, the number of valid bytes in the buffer is stored there
+ * @param flush call \ref ltc_encoder_buffer_flush - reset the buffer write-pointer
+ * @return pointer to encoder-buffer
+ */
+int ltc_encoder_get_bufferptr(LTCEncoder *e, ltcsnd_sample_t *buf, int flush);
 
 /**
  * reset the write-pointer of the encoder-buffer
@@ -654,12 +665,25 @@ void ltc_encoder_buffer_flush(LTCEncoder *e);
  * sample-rate and frame-rate.  ie. (1 + sample-rate / fps) bytes
  *
  * Note this returns the total size of the buffer, not the used/free
- * part. See also \ref ltc_encoder_get_bufptr
+ * part. See also \ref ltc_encoder_get_bufferptr
  *
  * @param e encoder handle
  * @return size of the allocated internal buffer.
  */
 size_t ltc_encoder_get_buffersize(LTCEncoder *e);
+
+/**
+ * Query the offset into the internal buffer. It is allocated
+ * to hold audio-frames for exactly one LTC frame for the given
+ * sample-rate and frame-rate.  ie. (1 + sample-rate / fps) bytes
+ *
+ * Note that this returns the used/free part of the buffer,
+ * not the total size. See also \ref ltc_encoder_get_bufferptr
+ *
+ * @param e encoder handle
+ * @return size of the offset into the internal buffer.
+ */
+size_t ltc_encoder_get_bufferoffset(LTCEncoder *e);
 
 /**
  * Change the encoder settings without re-allocating any
@@ -668,7 +692,7 @@ size_t ltc_encoder_get_buffersize(LTCEncoder *e);
  * and biphase state reset.
  *
  * This call will fail if the internal buffer is too small
- * to hold one full LTC frame. Use \ref ltc_encoder_set_bufsize to
+ * to hold one full LTC frame. Use \ref ltc_encoder_set_buffersize to
  * prepare an internal buffer large enough to accommodate all
  * sample_rate, fps combinations that you would like to re-init to.
  *
@@ -792,7 +816,7 @@ void ltc_encoder_set_filter(LTCEncoder *e, double rise_time);
  * Generate LTC audio for given byte of the LTC-frame and
  * place it into the internal buffer.
  *
- * see \ref ltc_encoder_get_buffer and  \ref ltc_encoder_get_bufptr
+ * see \ref ltc_encoder_copy_buffer and  \ref ltc_encoder_get_bufferptr
  *
  * LTC has 10 bytes per frame: 0 <= bytecnt < 10
  * use SMPTESetTime(..) to set the current frame before Encoding.
@@ -802,7 +826,7 @@ void ltc_encoder_set_filter(LTCEncoder *e, double rise_time);
  * see also \ref ltc_encoder_set_volume
  *
  * if speed is < 0, the bits are encoded in reverse.
- * slowdown > 10.0 requires custom buffer sizes; see \ref ltc_encoder_set_bufsize
+ * slowdown > 10.0 requires custom buffer sizes; see \ref ltc_encoder_set_buffersize
  *
  * @param e encoder handle
  * @param byte byte of the LTC-frame to encode 0..9
@@ -819,7 +843,7 @@ int ltc_encoder_encode_byte(LTCEncoder *e, int byte, double speed);
  *
  * Note: The internal buffer must be empty before calling this function.
  * Otherwise it may overflow. This is usually the case if it is read with
- * \ref ltc_encoder_get_buffer after calling this function.
+ * \ref ltc_encoder_copy_buffer after calling this function.
  *
  * The default internal buffersize is exactly one full LTC frame at speed 1.0.
  *
@@ -834,7 +858,7 @@ void ltc_encoder_encode_frame(LTCEncoder *e);
  *
  * Note: The internal buffer must be empty before calling this function.
  * Otherwise it may overflow. This is usually the case if it is read with
- * \ref ltc_encoder_get_buffer after calling this function.
+ * \ref ltc_encoder_copy_buffer after calling this function.
  *
  * @param e encoder handle
  */

--- a/src/ltc.h
+++ b/src/ltc.h
@@ -59,6 +59,12 @@ extern "C" {
 # endif
 #endif
 
+#if defined(__GNUC__) && __GNUC__ >= 4
+# define DEPRECATED_EXPORT __attribute__((__deprecated__))
+#else
+# define DEPRECATED_EXPORT
+#endif
+
 #include <stddef.h> /* size_t */
 
 #ifndef DOXYGEN_IGNORE
@@ -610,9 +616,21 @@ void ltc_encoder_get_frame(LTCEncoder *e, LTCFrame *f);
  * to hold \ref ltc_encoder_get_buffersize bytes
  * @return the number of bytes written to the memory area
  * pointed to by buf.
+ * @deprecated please use ltc_encoder_copy_buffer() instead
  */
-int ltc_encoder_get_buffer(LTCEncoder *e, ltcsnd_sample_t *buf);
+int ltc_encoder_get_buffer(LTCEncoder *e, ltcsnd_sample_t *buf) DEPRECATED_EXPORT;
 
+/**
+* Copy the accumulated encoded audio to the given
+* sample-buffer and flush the internal buffer.
+*
+* @param e encoder handle
+* @param buf place to store the audio-samples, needs to be large enough
+* to hold \ref ltc_encoder_get_buffersize bytes
+* @return the number of bytes written to the memory area
+* pointed to by buf.
+*/
+int ltc_encoder_copy_buffer(LTCEncoder *e, ltcsnd_sample_t *buf);
 
 /**
  * Retrieve a pointer to the accumulated encoded audio-data.
@@ -695,8 +713,28 @@ void ltc_encoder_reset(LTCEncoder *e);
  * @param fps video-frames per second (e.g. 25.0)
  * @return 0 on success, -1 if allocation fails (which makes the
  *   encoder unusable, call \ref ltc_encoder_free or realloc the buffer)
+ * @deprecated please use ltc_encoder_set_buffersize() instead
  */
-int ltc_encoder_set_bufsize(LTCEncoder *e, double sample_rate, double fps);
+int ltc_encoder_set_bufsize(LTCEncoder *e, double sample_rate, double fps) DEPRECATED_EXPORT;
+
+/**
+ * Configure a custom size for the internal buffer.
+ *
+ * This is needed if you are planning to call \ref ltc_encoder_reinit()
+ * or if you want to keep more than one LTC frame's worth of data in
+ * the library's internal buffer.
+ *
+ * The buffer-size is (1 + sample_rate / fps) bytes.
+ * resizing the internal buffer will flush all existing data
+ * in it - alike \ref ltc_encoder_buffer_flush.
+ *
+ * @param e encoder handle
+ * @param sample_rate audio sample rate (eg. 48000)
+ * @param fps video-frames per second (e.g. 25.0)
+ * @return 0 on success, -1 if allocation fails (which makes the
+ *   encoder unusable, call \ref ltc_encoder_free or realloc the buffer)
+ */
+int ltc_encoder_set_buffersize(LTCEncoder *e, double sample_rate, double fps);
 
 /**
  * Query the volume of the generated LTC signal

--- a/src/timecode.c
+++ b/src/timecode.c
@@ -431,20 +431,20 @@ int ltc_frame_decrement(LTCFrame* frame, int fps, enum LTC_TV_STANDARD standard,
 	return rv;
 }
 
-int parse_bcg_flags(LTCFrame *f, enum LTC_TV_STANDARD standard) {
+int ltc_frame_parse_bcg_flags(LTCFrame *frame, enum LTC_TV_STANDARD standard) {
 	switch (standard) {
 		case LTC_TV_625_50: /* 25 fps mode */
 			return (
-					  ((f->binary_group_flag_bit0)?4:0)
-					| ((f->binary_group_flag_bit1)?2:0)
-					| ((f->biphase_mark_phase_correction)?1:0)
+					  ((frame->binary_group_flag_bit0)?4:0)
+					| ((frame->binary_group_flag_bit1)?2:0)
+					| ((frame->biphase_mark_phase_correction)?1:0)
 					);
 			break;
 		default: /* 24,30 fps mode */
 			return (
-					  ((f->binary_group_flag_bit2)?4:0)
-					| ((f->binary_group_flag_bit1)?2:0)
-					| ((f->binary_group_flag_bit0)?1:0)
+					  ((frame->binary_group_flag_bit2)?4:0)
+					| ((frame->binary_group_flag_bit1)?2:0)
+					| ((frame->binary_group_flag_bit0)?1:0)
 					);
 			break;
 	}

--- a/src/timecode.c
+++ b/src/timecode.c
@@ -449,3 +449,7 @@ int ltc_frame_parse_bcg_flags(LTCFrame *frame, enum LTC_TV_STANDARD standard) {
 			break;
 	}
 }
+
+int parse_bcg_flags(LTCFrame *frame, enum LTC_TV_STANDARD standard) {
+        return ltc_frame_parse_bcg_flags(frame, standard);
+}


### PR DESCRIPTION
1) `ltc_frame_get_user_bits()`:
used binary OR operator instead of arithmetic + operator.
Faster to compute and more appropriate for bit manipulations.

2) deprecated `parse_bcg_flags()` and renamed it `ltc_frame_parse_bcg_flags()`
What does 'bcg' stand for BTW?

3) deprecated `ltc_encoder_get_bufptr()` and renamed it `ltc_encoder_get_bufferptr()`
Reason for deprecation was a change in argument order that is more consistent with other functions such as `ltc_encoder_get_buffer()`, `ltc_encoder_copy_buffer()`, etc...
So we set the buffer pointer by passing it as an argument by reference and we return the size/number of bytes.
In the future you may want to set the size by reference as well and use the return value for a status/error indicator, as you are already doing in some other functions.

4) fixed some comments that were referencing deprecated functions

Both deprecated functions are exported and turned them into wrappers for the new functions as I did previously. Nothing should break.

Your library works really well. I have just finished writing an encoder Max/MSP external, that allows you to change FPS, sample rate and volume on-the-fly in real time. I am gonna start writing the decoder part now.